### PR TITLE
Show shelf expire time for holds in PINES

### DIFF
--- a/Source/Models/HoldRecord.swift
+++ b/Source/Models/HoldRecord.swift
@@ -85,7 +85,7 @@ class HoldRecord {
             if App.config.enableHoldShowExpiration,
                let date = shelfExpireDate {
                 let dateStr = OSRFObject.outputDateFormatter.string(from: date)
-                str = "\(str)\nExpires \(dateStr)"
+                str = "\(str)\n\(R.getString("Expires")) \(dateStr)"
             }
             return str
         } else if s == 7 {

--- a/Source/pines_app/PinesAppConfiguration.swift
+++ b/Source/pines_app/PinesAppConfiguration.swift
@@ -30,7 +30,7 @@ class PinesAppConfiguration: BaseAppConfiguration {
     override var detailsExtraLinkFragment: String? { return "awards" }
 
     override var enableHoldShowQueuePosition: Bool { return false }
-    override var enableHoldShowExpiration: Bool { return false }
+    override var enableHoldShowExpiration: Bool { return true }
     override var enableHoldPhoneNotification: Bool { return true }
     override var enableHoldShowPickupLib: Bool { return true }
     override var enablePartHolds: Bool { return true }

--- a/Source/pines_app/custom_strings.json
+++ b/Source/pines_app/custom_strings.json
@@ -2,5 +2,6 @@
 "All parts": "Any part",
 "button_pay_fines": "Pay all charges",
 "Fines": "Charges",
-"balance_owed": "Charges"
+"balance_owed": "Charges",
+"Expires": "Pick up by"
 }


### PR DESCRIPTION
Shows the shelf expire time in the PINES app and attempts to tweak the wording from 'Expires <date>' to 'Pick up by <date>'.

I can't test on ios yet so this was my best guess at how to set up the string change.