### PR TITLE
Rename App.svc fields to remove redundancy

### DIFF
--- a/Source/App.swift
+++ b/Source/App.swift
@@ -45,7 +45,7 @@ class App {
     static var launchNotificationUserInfo: [AnyHashable: Any]?
 
     /// TODO: make this injectable
-    static var serviceConfig: ServiceConfig = EvergreenServiceConfig()
+    static var svc: ServiceConfig = EvergreenServiceConfig()
 
     /// the valet saves things in the iOS keychain
     static let valet = Valet.valet(with: Identifier(nonEmpty: "Hemlock")!, accessibility: .whenUnlockedThisDeviceOnly)

--- a/Source/Data/Service/ServiceConfig.swift
+++ b/Source/Data/Service/ServiceConfig.swift
@@ -17,12 +17,12 @@
 import Foundation
 
 protocol ServiceConfig {
-    var loaderService: LoaderService { get }
-    var authService: AuthService { get }
-    var biblioService: BiblioService { get }
-    var circService: CircService { get }
-    var consortiumService: ConsortiumService { get }
-    var orgService: OrgService { get }
-    var searchService: SearchService { get }
-    var userService: UserService { get }
+    var loader: LoaderService { get }
+    var auth: AuthService { get }
+    var biblio: BiblioService { get }
+    var circ: CircService { get }
+    var consortium: ConsortiumService { get }
+    var org: OrgService { get }
+    var search: SearchService { get }
+    var user: UserService { get }
 }

--- a/Source/Data/Util/CopyLocationCounts+.swift
+++ b/Source/Data/Util/CopyLocationCounts+.swift
@@ -27,7 +27,7 @@ extension CopyLocationCounts {
     var copyLocationLabel: CopyLocationLabel {
         var heading = ""
         var subhead = ""
-        let consortiumService = App.serviceConfig.consortiumService
+        let consortiumService = App.svc.consortium
         if let org = consortiumService.find(byID: orgID) {
             heading = org.name
             if App.config.groupCopyInfoBySystem,
@@ -48,7 +48,7 @@ extension CopyLocationCounts {
 /// - Returns: array filtered to visible orgs and sorted
 func visibleCopyLocationCounts(from array: [CopyLocationCounts]) -> [CopyLocationCounts] {
     var ret: [CopyLocationCounts] = []
-    let consortiumService = App.serviceConfig.consortiumService
+    let consortiumService = App.svc.consortium
 
     // if a branch is not opac visible, its copies should not be visible
     for elem in array {

--- a/Source/Evergreen/Data/Model/EvergreenAccount.swift
+++ b/Source/Evergreen/Data/Model/EvergreenAccount.swift
@@ -167,7 +167,7 @@ class EvergreenAccount : Account {
         {
             print("[fcm] updating stored token")
             do {
-                try await App.serviceConfig.userService.updatePushNotificationToken(account: self, token: currentFCMToken)
+                try await App.svc.user.updatePushNotificationToken(account: self, token: currentFCMToken)
                 Analytics.logEvent(event: Analytics.Event.fcmTokenUpdate, parameters: [Analytics.Param.result: Analytics.Value.ok])
             } catch {
                 Analytics.logEvent(event: Analytics.Event.fcmTokenUpdate, parameters: [Analytics.Param.result: error.localizedDescription])

--- a/Source/Evergreen/Data/Service/EvergreenLoaderService.swift
+++ b/Source/Evergreen/Data/Service/EvergreenLoaderService.swift
@@ -145,7 +145,7 @@ class EvergreenLoaderService: LoaderService {
                    !org.areSettingsLoaded
                 {
                     group.addTask {
-                        try await App.serviceConfig.orgService.loadOrgSettings(forOrgID: org.id)
+                        try await App.svc.org.loadOrgSettings(forOrgID: org.id)
                     }
                 }
             }

--- a/Source/Evergreen/Data/Service/EvergreenServiceConfig.swift
+++ b/Source/Evergreen/Data/Service/EvergreenServiceConfig.swift
@@ -17,12 +17,12 @@
 import Foundation
 
 class EvergreenServiceConfig: ServiceConfig {
-    var loaderService: any LoaderService = EvergreenLoaderService()
-    var authService: any AuthService = EvergreenAuthService()
-    var biblioService: any BiblioService = EvergreenBiblioService()
-    var circService: any CircService = EvergreenCircService()
-    var consortiumService: any ConsortiumService = EvergreenConsortiumService()
-    var orgService: any OrgService = EvergreenOrgService()
-    var searchService: any SearchService = EvergreenSearchService()
-    var userService: any UserService = EvergreenUserService()
+    var loader: any LoaderService = EvergreenLoaderService()
+    var auth: any AuthService = EvergreenAuthService()
+    var biblio: any BiblioService = EvergreenBiblioService()
+    var circ: any CircService = EvergreenCircService()
+    var consortium: any ConsortiumService = EvergreenConsortiumService()
+    var org: any OrgService = EvergreenOrgService()
+    var search: any SearchService = EvergreenSearchService()
+    var user: any UserService = EvergreenUserService()
 }

--- a/Source/Scenes/BookBagDetails/BookBagDetailsViewController.swift
+++ b/Source/Scenes/BookBagDetails/BookBagDetailsViewController.swift
@@ -74,7 +74,7 @@ class BookBagDetailsViewController : UITableViewController {
         activityIndicator.startAnimating()
 
         do {
-            try await App.serviceConfig.userService.loadPatronListItems(account: account, patronList: bookBag)
+            try await App.svc.user.loadPatronListItems(account: account, patronList: bookBag)
             os_log("fetched %d items", log: self.log, type: .info, bookBag.items.count)
 
             try await withThrowingTaskGroup(of: Void.self) { group in
@@ -95,7 +95,7 @@ class BookBagDetailsViewController : UITableViewController {
     }
 
     func loadItemDetails(forItem item: ListItem) async throws -> Void {
-        try await App.serviceConfig.biblioService.loadRecordDetails(forRecord: item.record, needMARC: App.config.needMARCRecord)
+        try await App.svc.biblio.loadRecordDetails(forRecord: item.record, needMARC: App.config.needMARCRecord)
     }
 
     @objc func sortButtonPressed(sender: UIBarButtonItem) {
@@ -203,7 +203,7 @@ class BookBagDetailsViewController : UITableViewController {
     @MainActor
     func deleteItem(account: Account, bookBag: PatronList, item: ListItem) async {
         do {
-            try await App.serviceConfig.userService.removeItemFromPatronList(account: account, listId: bookBag.id, itemId: item.id)
+            try await App.svc.user.removeItemFromPatronList(account: account, listId: bookBag.id, itemId: item.id)
             Analytics.logEvent(event: Analytics.Event.bookbagDeleteItem, parameters: [Analytics.Param.result: Analytics.Value.ok])
             self.bookBag?.items.removeAll(where: { $0.id == item.id })
             self.updateItems()

--- a/Source/Scenes/BookBags/BookBagsViewController.swift
+++ b/Source/Scenes/BookBags/BookBagsViewController.swift
@@ -67,13 +67,13 @@ class BookBagsViewController : UITableViewController {
         activityIndicator.startAnimating()
 
         do {
-            try await App.serviceConfig.userService.loadPatronLists(account: account)
+            try await App.svc.user.loadPatronLists(account: account)
             os_log("[lists] fetched %d lists", log: self.log, type: .info, account.patronLists.count)
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 for list in account.patronLists {
                     group.addTask {
-                        try await App.serviceConfig.userService.loadPatronListItems(account: account, patronList: list)
+                        try await App.svc.user.loadPatronListItems(account: account, patronList: list)
                     }
                 }
                 try await group.waitForAll()
@@ -116,7 +116,7 @@ class BookBagsViewController : UITableViewController {
         }
 
         do {
-            try await App.serviceConfig.userService.createPatronList(account: account, name: name, description: description ?? "")
+            try await App.svc.user.createPatronList(account: account, name: name, description: description ?? "")
             self.navigationController?.view.makeToast("List created")
             await self.fetchData()
         } catch {
@@ -127,7 +127,7 @@ class BookBagsViewController : UITableViewController {
     @MainActor
     func deleteList(account: Account, listId: Int, indexPath: IndexPath) async {
         do {
-            try await App.serviceConfig.userService.deletePatronList(account: account, listId: listId)
+            try await App.svc.user.deletePatronList(account: account, listId: listId)
             account.removePatronList(at: indexPath.row)
             self.updateItems()
         } catch {

--- a/Source/Scenes/Checkouts/CheckoutsViewController.swift
+++ b/Source/Scenes/Checkouts/CheckoutsViewController.swift
@@ -79,12 +79,12 @@ class CheckoutsViewController: UIViewController {
         let startOfFetch = Date()
 
         do {
-            let checkouts = try await App.serviceConfig.circService.fetchCheckouts(account: account)
+            let checkouts = try await App.svc.circ.fetchCheckouts(account: account)
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 for circRecord in checkouts {
                     group.addTask {
-                        try await App.serviceConfig.circService.loadCheckoutDetails(account: account, circRecord: circRecord)
+                        try await App.svc.circ.loadCheckoutDetails(account: account, circRecord: circRecord)
                     }
                 }
                 try await group.waitForAll()
@@ -130,7 +130,7 @@ class CheckoutsViewController: UIViewController {
         activityIndicator.startAnimating()
 
         do {
-            let _ = try await App.serviceConfig.circService.renewCheckout(account: account, targetCopy: targetCopy)
+            let _ = try await App.svc.circ.renewCheckout(account: account, targetCopy: targetCopy)
 
             self.navigationController?.view.makeToast("Item renewed")
             Task { await self.fetchData() }
@@ -210,7 +210,7 @@ class CheckoutsViewController: UIViewController {
         activityIndicator.startAnimating()
 
         do {
-            try await App.serviceConfig.userService.enableCheckoutHistory(account: account)
+            try await App.svc.user.enableCheckoutHistory(account: account)
             self.showAlert(title: "Success", message: "Items you check out from now on will appear in your history.")
         } catch {
             self.presentGatewayAlert(forError: error)

--- a/Source/Scenes/CopyInfo/CopyInfoViewController.swift
+++ b/Source/Scenes/CopyInfo/CopyInfoViewController.swift
@@ -66,7 +66,7 @@ class CopyInfoViewController: UIViewController {
         }
 
         do {
-            let items = try await App.serviceConfig.searchService.fetchCopyLocationCounts(recordID: recordID, orgID: org.id, orgLevel: org.level)
+            let items = try await App.svc.search.fetchCopyLocationCounts(recordID: recordID, orgID: org.id, orgLevel: org.level)
             self.updateItems(withCopyLocationCounts: items)
         } catch {
             self.presentGatewayAlert(forError: error)

--- a/Source/Scenes/Fines/FinesViewController.swift
+++ b/Source/Scenes/Fines/FinesViewController.swift
@@ -113,7 +113,7 @@ class FinesViewController: UIViewController {
 
     func fetchHomeOrgSettings(account: Account) async throws {
         if let homeOrgID = account.homeOrgID {
-            try await App.serviceConfig.orgService.loadOrgSettings(forOrgID: homeOrgID)
+            try await App.svc.org.loadOrgSettings(forOrgID: homeOrgID)
         }
     }
 
@@ -124,7 +124,7 @@ class FinesViewController: UIViewController {
         activityIndicator.startAnimating()
 
         do {
-            async let chargesFuture = App.serviceConfig.userService.fetchPatronCharges(account: account)
+            async let chargesFuture = App.svc.user.fetchPatronCharges(account: account)
 
             let (_, charges) = try await (fetchHomeOrgSettings(account: account), chargesFuture)
 
@@ -141,7 +141,7 @@ class FinesViewController: UIViewController {
     func updatePayFinesButton() {
         guard let account = App.account else { return }
         if App.config.enablePayFines,
-           App.serviceConfig.userService.isPayChargesEnabled(account: account),
+           App.svc.user.isPayChargesEnabled(account: account),
            anyBalanceOwed
         {
             Style.styleButton(asInverse: payFinesButton)
@@ -152,7 +152,7 @@ class FinesViewController: UIViewController {
 
     @objc func payFinesButtonPressed(_ sender: Any) {
         guard let account = App.account else { return }
-        let url = App.config.payChargesUrl ?? App.serviceConfig.userService.payChargesUrl(account: account)
+        let url = App.config.payChargesUrl ?? App.svc.user.payChargesUrl(account: account)
         launchURL(url: url)
     }
 

--- a/Source/Scenes/History/HistoryViewController.swift
+++ b/Source/Scenes/History/HistoryViewController.swift
@@ -75,7 +75,7 @@ class HistoryViewController: UITableViewController {
         startOfFetch = Date()
 
         do {
-            self.items = try await App.serviceConfig.circService.fetchCheckoutHistory(account: account)
+            self.items = try await App.svc.circ.fetchCheckoutHistory(account: account)
             Analytics.logEvent(event: Analytics.Event.historyLoad, parameters: [Analytics.Param.numItems: items.count])
             Task {
                 await prefetchCircDetails()
@@ -101,7 +101,7 @@ class HistoryViewController: UITableViewController {
         //let preloadItems = items.prefix(maxRecordsToPreload)
         let preloadItems = items
 
-        let circService = App.serviceConfig.circService
+        let circService = App.svc.circ
         await withTaskGroup(of: Void.self) { group in
             for item in preloadItems {
                 group.addTask {
@@ -141,8 +141,8 @@ class HistoryViewController: UITableViewController {
     @MainActor
     func disableCheckoutHistory(account: Account) async {
         do {
-            try await App.serviceConfig.userService.disableCheckoutHistory(account: account)
-            try await App.serviceConfig.userService.clearCheckoutHistory(account: account)
+            try await App.svc.user.disableCheckoutHistory(account: account)
+            try await App.svc.user.clearCheckoutHistory(account: account)
             self.navigationController?.popViewController(animated: true)
         } catch {
             self.presentGatewayAlert(forError: error)
@@ -211,7 +211,7 @@ class HistoryViewController: UITableViewController {
 
             // async load the metadata
             Task {
-                try? await App.serviceConfig.circService.loadHistoryDetails(historyRecord: item)
+                try? await App.svc.circ.loadHistoryDetails(historyRecord: item)
                 await MainActor.run { self.setCellMetadata(cell, forItem: item) }
             }
         }

--- a/Source/Scenes/Holds/HoldsViewController.swift
+++ b/Source/Scenes/Holds/HoldsViewController.swift
@@ -70,7 +70,7 @@ class HoldsViewController: UIViewController {
         activityIndicator.startAnimating()
 
         do {
-            items = try await App.serviceConfig.circService.fetchHolds(account: account)
+            items = try await App.svc.circ.fetchHolds(account: account)
             try await loadHoldDetails(account: account)
 
             self.didCompleteFetch = true
@@ -89,7 +89,7 @@ class HoldsViewController: UIViewController {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for hold in self.items {
                 group.addTask {
-                    try await App.serviceConfig.circService.loadHoldDetails(account: account, hold: hold)
+                    try await App.svc.circ.loadHoldDetails(account: account, hold: hold)
                 }
             }
             try await group.waitForAll()
@@ -134,7 +134,7 @@ class HoldsViewController: UIViewController {
     @MainActor
     func cancelHold(account: Account, holdID: Int) async {
         do {
-            let _ = try await App.serviceConfig.circService.cancelHold(account: account, holdID: holdID)
+            let _ = try await App.svc.circ.cancelHold(account: account, holdID: holdID)
             self.logCancelHold()
             self.navigationController?.view.makeToast("Hold cancelled")
             self.didCompleteFetch = false

--- a/Source/Scenes/Login/LoginViewController.swift
+++ b/Source/Scenes/Login/LoginViewController.swift
@@ -95,7 +95,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         do {
             let options = LoaderServiceOptions(clientCacheKey: Bundle.appVersionUrlSafe,
                                              useHierarchicalOrgTree: App.config.enableHierarchicalOrgTree)
-            try await App.serviceConfig.loaderService.loadStartupPrerequisites(options: options)
+            try await App.svc.loader.loadStartupPrerequisites(options: options)
 
             self.loginButton.isEnabled = true
             self.didCompleteFetch = true
@@ -171,10 +171,10 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
 
         var credential = Credential(username: username, password: password)
         do {
-            let authtoken = try await App.serviceConfig.authService.fetchAuthToken(credential: credential)
-            let account = App.serviceConfig.userService.makeAccount(username: username, password: password, authToken: authtoken)
+            let authtoken = try await App.svc.auth.fetchAuthToken(credential: credential)
+            let account = App.svc.user.makeAccount(username: username, password: password, authToken: authtoken)
 
-            try await App.serviceConfig.userService.loadSession(account: account)
+            try await App.svc.user.loadSession(account: account)
 
             credential.displayName = account.displayName
             self.onSuccessfulLogin(account: account, credential: credential)
@@ -196,8 +196,8 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     }
 
     func logSuccessfulLogin(account: Account, numCredentials: Int) {
-        let homeOrg = App.serviceConfig.consortiumService.find(byID: account.homeOrgID)
-        let parentOrg = App.serviceConfig.consortiumService.find(byID: homeOrg?.parent)
+        let homeOrg = App.svc.consortium.find(byID: account.homeOrgID)
+        let parentOrg = App.svc.consortium.find(byID: homeOrg?.parent)
         Analytics.setUserProperty(value: homeOrg?.shortname, forName: Analytics.UserProperty.homeOrg)
         Analytics.setUserProperty(value: parentOrg?.shortname, forName: Analytics.UserProperty.parentOrg)
         Analytics.setUserProperty(value: Analytics.boolValue(numCredentials > 1), forName: Analytics.UserProperty.multipleAccounts)

--- a/Source/Scenes/Main/MainBaseViewController.swift
+++ b/Source/Scenes/Main/MainBaseViewController.swift
@@ -34,7 +34,7 @@ class MainBaseViewController: UIViewController {
 #else
         let didHandleNotification = false
 #endif
-        systemAlertPending = !didHandleNotification && App.serviceConfig.consortiumService.alertBanner != nil
+        systemAlertPending = !didHandleNotification && App.svc.consortium.alertBanner != nil
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -142,7 +142,7 @@ class MainBaseViewController: UIViewController {
     }
 
     func showSystemAlert() {
-        guard let msg = App.serviceConfig.consortiumService.alertBanner else { return }
+        guard let msg = App.svc.consortium.alertBanner else { return }
         guard !systemAlertIsSquelched(msg) else { return }
         let alertController = UIAlertController(title: "System Alert", message: msg, preferredStyle: .alert)
         Style.styleAlertController(alertController)

--- a/Source/Scenes/Main/MainGridViewController.swift
+++ b/Source/Scenes/Main/MainGridViewController.swift
@@ -73,7 +73,7 @@ class MainGridViewController: MainBaseViewController {
         guard let orgID = App.account?.homeOrgID else { return }
 
         do {
-            try await App.serviceConfig.orgService.loadOrgSettings(forOrgID: orgID)
+            try await App.svc.org.loadOrgSettings(forOrgID: orgID)
             didFetchHomeOrgSettings = true
             onHomeOrgSettingsLoaded(homeOrgID: orgID)
         } catch {
@@ -82,7 +82,7 @@ class MainGridViewController: MainBaseViewController {
     }
 
     func onHomeOrgSettingsLoaded(homeOrgID orgID: Int) {
-        let org = App.serviceConfig.consortiumService.find(byID: orgID)
+        let org = App.svc.consortium.find(byID: orgID)
         self.loadButtons(forOrg: org)
         self.collectionView.reloadData()
     }

--- a/Source/Scenes/Main/MainListViewController.swift
+++ b/Source/Scenes/Main/MainListViewController.swift
@@ -164,7 +164,7 @@ class MainListViewController: MainBaseViewController {
         guard let orgID = App.account?.homeOrgID else { return }
 
         do {
-            try await App.serviceConfig.orgService.loadOrgSettings(forOrgID: orgID)
+            try await App.svc.org.loadOrgSettings(forOrgID: orgID)
             didFetchHomeOrgSettings = true
             onHomeOrgSettingsLoaded(homeOrgID: orgID)
         } catch {
@@ -173,7 +173,7 @@ class MainListViewController: MainBaseViewController {
     }
 
     func onHomeOrgSettingsLoaded(homeOrgID orgID: Int) {
-        if let org = App.serviceConfig.consortiumService.find(byID: orgID),
+        if let org = App.svc.consortium.find(byID: orgID),
            let eventsURL = org.eventsURL,
            !eventsURL.isEmpty,
            let url = URL(string: eventsURL)
@@ -190,7 +190,7 @@ class MainListViewController: MainBaseViewController {
     func fetchMessages(account: Account) async {
 
         do {
-            let messages = try await App.serviceConfig.userService.fetchPatronMessages(account: account)
+            let messages = try await App.svc.user.fetchPatronMessages(account: account)
             self.updateMessagesBadge(messages: messages)
         } catch {
             self.presentGatewayAlert(forError: error)

--- a/Source/Scenes/Messages/MessageDetailsViewController.swift
+++ b/Source/Scenes/Messages/MessageDetailsViewController.swift
@@ -61,7 +61,7 @@ class MessageDetailsViewController: UIViewController {
         guard let messageID = message?.id else { return }
 
         do {
-            try await App.serviceConfig.userService.markMessageRead(account: account, messageID: messageID)
+            try await App.svc.user.markMessageRead(account: account, messageID: messageID)
         } catch {
             self.presentGatewayAlert(forError: error, title: "Error marking message read")
         }
@@ -70,7 +70,7 @@ class MessageDetailsViewController: UIViewController {
     @MainActor
     func markMessageUnread(account: Account, messageID: Int) async {
         do {
-            try await App.serviceConfig.userService.markMessageUnread(account: account, messageID: messageID)
+            try await App.svc.user.markMessageUnread(account: account, messageID: messageID)
 
         } catch {
             self.presentGatewayAlert(forError: error, title: "Error marking message unread")

--- a/Source/Scenes/Messages/MessagesViewController.swift
+++ b/Source/Scenes/Messages/MessagesViewController.swift
@@ -64,7 +64,7 @@ class MessagesViewController: UITableViewController {
         activityIndicator.startAnimating()
 
         do {
-            let messages = try await App.serviceConfig.userService.fetchPatronMessages(account: account)
+            let messages = try await App.svc.user.fetchPatronMessages(account: account)
             self.didCompleteFetch = true
             self.updateItems(messages: messages)
         } catch {
@@ -82,7 +82,7 @@ class MessagesViewController: UITableViewController {
     @MainActor
     func markMessageDeleted(account: Account, message: PatronMessage) async {
         do {
-            try await App.serviceConfig.userService.markMessageDeleted(account: account, messageID: message.id)
+            try await App.svc.user.markMessageDeleted(account: account, messageID: message.id)
             await self.fetchData()
         } catch {
             self.presentGatewayAlert(forError: error, title: "Error deleting message")

--- a/Source/Scenes/OrgDetails/OrgDetailsViewController.swift
+++ b/Source/Scenes/OrgDetails/OrgDetailsViewController.swift
@@ -76,14 +76,14 @@ class OrgDetailsViewController: UIViewController {
     func fetchData() async {
         guard let account = App.account,
               let orgID = self.orgID,
-              let org = App.serviceConfig.consortiumService.find(byID: orgID) else { return }
+              let org = App.svc.consortium.find(byID: orgID) else { return }
 
         activityIndicator.startAnimating()
 
         do {
             _ = try await (
-                App.serviceConfig.orgService.loadOrgSettings(forOrgID: orgID),
-                App.serviceConfig.orgService.loadOrgDetails(account: account, forOrgID: orgID)
+                App.svc.org.loadOrgSettings(forOrgID: orgID),
+                App.svc.org.loadOrgDetails(account: account, forOrgID: orgID)
             )
         } catch {
             self.presentGatewayAlert(forError: error)
@@ -179,7 +179,7 @@ class OrgDetailsViewController: UIViewController {
     @objc func orgButtonPressed(sender: UIButton) {
         guard orgLabels.count > 0 else { return }
         guard let vc = UIStoryboard(name: "Options", bundle: nil).instantiateInitialViewController() as? OptionsViewController else { return }
-        let consortiumService = App.serviceConfig.consortiumService
+        let consortiumService = App.svc.consortium
 
         vc.title = "Library"
         vc.option = PickOneOption(optionLabels: consortiumService.orgSpinnerLabels, optionValues: consortiumService.orgSpinnerShortNames, optionIsPrimary: consortiumService.orgSpinnerIsPrimaryFlags)
@@ -192,7 +192,7 @@ class OrgDetailsViewController: UIViewController {
     }
 
     @objc func webSiteButtonPressed(sender: UIButton) {
-        let org = App.serviceConfig.consortiumService.find(byID: orgID)
+        let org = App.svc.consortium.find(byID: orgID)
         guard let infoURL = org?.infoURL,
             let url = URL(string: infoURL) else { return }
 //        let canOpen = UIApplication.shared.canOpenURL(url)
@@ -201,7 +201,7 @@ class OrgDetailsViewController: UIViewController {
     }
 
     @objc func mapButtonPressed(sender: UIButton) {
-        let org = App.serviceConfig.consortiumService.find(byID: orgID)
+        let org = App.svc.consortium.find(byID: orgID)
         guard let url = mapsURL(org: org) else { return }
 //        let canOpen = UIApplication.shared.canOpenURL(url)
 //        print("canOpen: \(canOpen)")
@@ -209,7 +209,7 @@ class OrgDetailsViewController: UIViewController {
     }
 
     @objc func emailButtonPressed(sender: UIButton) {
-        let org = App.serviceConfig.consortiumService.find(byID: orgID)
+        let org = App.svc.consortium.find(byID: orgID)
         guard let email = org?.email,
             let url = URL(string: "mailto:\(email)") else { return }
 //        let canOpen = UIApplication.shared.canOpenURL(url)
@@ -218,7 +218,7 @@ class OrgDetailsViewController: UIViewController {
     }
 
     @objc func phoneButtonPressed(sender: UIButton) {
-        let org = App.serviceConfig.consortiumService.find(byID: orgID)
+        let org = App.svc.consortium.find(byID: orgID)
         guard let number = org?.phoneNumber,
             let url = URL(string: "tel:\(number)") else { return }
 //        let canOpen = UIApplication.shared.canOpenURL(url)
@@ -353,6 +353,6 @@ class OrgDetailsViewController: UIViewController {
     }
 
     func onOrgTreeLoaded() {
-        orgLabels = App.serviceConfig.consortiumService.orgSpinnerLabels
+        orgLabels = App.svc.consortium.orgSpinnerLabels
     }
 }

--- a/Source/Scenes/Search/ResultsViewController.swift
+++ b/Source/Scenes/Search/ResultsViewController.swift
@@ -77,7 +77,7 @@ class ResultsViewController: UIViewController {
 
         // search
         do {
-            let results = try await App.serviceConfig.searchService.fetchSearchResults(queryString: query, limit: App.config.searchLimit)
+            let results = try await App.svc.search.fetchSearchResults(queryString: query, limit: App.config.searchLimit)
             let elapsed = -self.startOfSearch.timeIntervalSinceNow
             os_log("query.elapsed: %.3f", log: Gateway.log, type: .info, elapsed)
 
@@ -135,12 +135,12 @@ class ResultsViewController: UIViewController {
             showAlert(title: "Internal Error", error: HemlockError.shouldNotHappen("Missing search parameters"))
             return nil
         }
-        return App.serviceConfig.searchService.makeQueryString(searchParameters: sp)
+        return App.svc.search.makeQueryString(searchParameters: sp)
     }
 
     func logSearchEvent(withError error: Error? = nil, numResults: Int = 0) {
         guard let sp = searchParameters else { return }
-        let consortiumService = App.serviceConfig.consortiumService
+        let consortiumService = App.svc.consortium
         let selectedOrg = consortiumService.find(byShortName: sp.searchOrg)
         let defaultOrg = consortiumService.find(byID: App.account?.searchOrgID)
         let homeOrg = consortiumService.find(byID: App.account?.homeOrgID)

--- a/Source/Scenes/Search/SearchViewController.swift
+++ b/Source/Scenes/Search/SearchViewController.swift
@@ -89,7 +89,7 @@ class SearchViewController: UIViewController {
     }
 
     func setupOptionsTable() {
-        let consortiumService = App.serviceConfig.consortiumService
+        let consortiumService = App.svc.consortium
         options = []
         options.append(StringOption(
             key: AppState.Str.searchClass,

--- a/Source/Utils/Analytics.swift
+++ b/Source/Utils/Analytics.swift
@@ -107,7 +107,7 @@ class Analytics {
         if selectedOrg.id == homeOrg.id {
             return "home"
         }
-        if selectedOrg.id == App.serviceConfig.consortiumService.consortiumOrgID {
+        if selectedOrg.id == App.svc.consortium.consortiumOrgID {
             return selectedOrg.shortname
         }
         return "other"

--- a/Source/Utils/BibRecord+prefetch.swift
+++ b/Source/Utils/BibRecord+prefetch.swift
@@ -28,8 +28,8 @@ extension BibRecord {
     func prefetch() async -> Void {
         print("\(Utils.tt) id=\(String(format: "%7d", id)) prefetch hasMetadata=\(self.hasMetadata) hasAttrs=\(self.hasAttributes)")
 
-        async let details: Void = App.serviceConfig.biblioService.loadRecordDetails(forRecord: self, needMARC: false)
-        async let attrs: Void = App.serviceConfig.biblioService.loadRecordAttributes(forRecord: self)
+        async let details: Void = App.svc.biblio.loadRecordDetails(forRecord: self, needMARC: false)
+        async let attrs: Void = App.svc.biblio.loadRecordAttributes(forRecord: self)
         let _ = try? await (details, attrs)
     }
 }

--- a/Tests/LiveServiceTests.swift
+++ b/Tests/LiveServiceTests.swift
@@ -192,10 +192,10 @@ class LiveServiceTests: XCTestCase {
     func test_orgTree() async throws {
         try await once_loadStartupPrerequisites()
 
-        let org = App.serviceConfig.consortiumService.find(byID: 1)
+        let org = App.svc.consortium.find(byID: 1)
         XCTAssertNotNil(org)
         XCTAssertNotNil(org?.name)
-        let consortium = App.serviceConfig.consortiumService.find(byID: App.serviceConfig.consortiumService.consortiumOrgID)
+        let consortium = App.svc.consortium.find(byID: App.svc.consortium.consortiumOrgID)
         XCTAssertNotNil(consortium)
         XCTAssertEqual(1, consortium?.id)
     }

--- a/Tests/Utils/AnalyticsTests.swift
+++ b/Tests/Utils/AnalyticsTests.swift
@@ -53,7 +53,7 @@ class AnalyticsTests: XCTestCase {
     }
 
     func test_orgDimension() {
-        let consortiumService = App.serviceConfig.consortiumService
+        let consortiumService = App.svc.consortium
         let CONS = consortiumService.find(byShortName: "CONS")
         let BR1 = consortiumService.find(byShortName: "BR1")
         let BR2 = consortiumService.find(byShortName: "BR2")


### PR DESCRIPTION
Its most common usage is now App.svc.consortium
instead of App.serviceConfig.consortiumService