### PR TITLE
Add AttributedAlertController to handle HTML alerts

### DIFF
--- a/Hemlock.xcodeproj/project.pbxproj
+++ b/Hemlock.xcodeproj/project.pbxproj
@@ -665,6 +665,15 @@
 		D2572B2724AD7A13000BA698 /* AppFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2572B2324AD7A13000BA698 /* AppFactory.swift */; };
 		D2572B2824AD7A13000BA698 /* MoTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2572B2424AD7A13000BA698 /* MoTheme.swift */; };
 		D2572B2924AD7A13000BA698 /* MoAppBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2572B2524AD7A13000BA698 /* MoAppBehavior.swift */; };
+		D2579CBB2FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */; };
+		D2579CBC2FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */; };
+		D2579CBD2FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */; };
+		D2579CBE2FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */; };
+		D2579CBF2FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */; };
+		D2579CC02FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */; };
+		D2579CC12FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */; };
+		D2579CC22FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */; };
+		D2579CC32FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */; };
 		D2592D7D24AFA4C0009E80EC /* mo.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D2592D7C24AFA4C0009E80EC /* mo.xcassets */; };
 		D259671924511CA90076267D /* UtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D259671824511CA90076267D /* UtilsTests.swift */; };
 		D25D97222E38412400DBFD65 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D25D97212E38412400DBFD65 /* GoogleService-Info.plist */; };
@@ -2076,6 +2085,7 @@
 		D2572B2324AD7A13000BA698 /* AppFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppFactory.swift; sourceTree = "<group>"; };
 		D2572B2424AD7A13000BA698 /* MoTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoTheme.swift; sourceTree = "<group>"; };
 		D2572B2524AD7A13000BA698 /* MoAppBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoAppBehavior.swift; sourceTree = "<group>"; };
+		D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedAlertController.swift; sourceTree = "<group>"; };
 		D2592D7C24AFA4C0009E80EC /* mo.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = mo.xcassets; sourceTree = "<group>"; };
 		D259671824511CA90076267D /* UtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsTests.swift; sourceTree = "<group>"; };
 		D25D97212E38412400DBFD65 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -2568,6 +2578,7 @@
 				D22AE118221B75FC0089C196 /* AFSession+.swift */,
 				D2DF196720CEF68700085255 /* Analytics.swift */,
 				D21FF9B82E706D760058E2D3 /* AppState.swift */,
+				D2579CBA2FA8E2A100F8DB6B /* AttributedAlertController.swift */,
 				D27DF20721AB424A002DCC47 /* BarcodeUtils.swift */,
 				D28F5E6C29CF8E0700FAAAD6 /* BibRecord+prefetch.swift */,
 				D2A81795224699C700340074 /* Bundle+.swift */,
@@ -3992,6 +4003,7 @@
 				D210EBD522B1EE55002FB5E0 /* MainTableViewCell.swift in Sources */,
 				D210EBD622B1EE55002FB5E0 /* EvergreenHoldRecord.swift in Sources */,
 				D210EBD722B1EE55002FB5E0 /* Bundle+.swift in Sources */,
+				D2579CBD2FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */,
 				D292736D2ED5348A004CAD82 /* HoldRecord.swift in Sources */,
 				D20B2FF422CE7BF500F69848 /* Link.swift in Sources */,
 				D283B0C12E426A3100AE5F43 /* EvergreenOrgService.swift in Sources */,
@@ -4208,6 +4220,7 @@
 				D23E9F9923B9200A0030F5C1 /* CheckoutsViewController.swift in Sources */,
 				D23E9FEF23B923B80030F5C1 /* SagecatTheme.swift in Sources */,
 				D23E9F9B23B9200A0030F5C1 /* Theme.swift in Sources */,
+				D2579CC22FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */,
 				D23E9F9C23B9200A0030F5C1 /* XUtils.swift in Sources */,
 				D2E7E3172F4A28350066D52B /* Collection+.swift in Sources */,
 				D23E9F9D23B9200A0030F5C1 /* Analytics.swift in Sources */,
@@ -4362,6 +4375,7 @@
 				D2477BE924785A6B00FD4CF6 /* Theme.swift in Sources */,
 				D2477BEA24785A6B00FD4CF6 /* XUtils.swift in Sources */,
 				D2477BEB24785A6B00FD4CF6 /* Analytics.swift in Sources */,
+				D2579CBB2FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */,
 				D2477BEE24785A6B00FD4CF6 /* MD5.swift in Sources */,
 				D2E7E3192F4A28350066D52B /* Collection+.swift in Sources */,
 				D2477BEF24785A6B00FD4CF6 /* FinesTableViewCell.swift in Sources */,
@@ -4516,6 +4530,7 @@
 				D2572ADA24AD7755000BA698 /* Theme.swift in Sources */,
 				D2572ADB24AD7755000BA698 /* XUtils.swift in Sources */,
 				D2572B2724AD7A13000BA698 /* AppFactory.swift in Sources */,
+				D2579CC02FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */,
 				D2572ADC24AD7755000BA698 /* Analytics.swift in Sources */,
 				D2E7E31A2F4A28350066D52B /* Collection+.swift in Sources */,
 				D2572ADF24AD7755000BA698 /* MD5.swift in Sources */,
@@ -4670,6 +4685,7 @@
 				D25EEC7D28A1E8310090F108 /* CheckoutsViewController.swift in Sources */,
 				D25EEC7F28A1E8310090F108 /* Theme.swift in Sources */,
 				D25EEC8028A1E8310090F108 /* XUtils.swift in Sources */,
+				D2579CBE2FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */,
 				D25EEC8228A1E8310090F108 /* Analytics.swift in Sources */,
 				D2E7E3152F4A28350066D52B /* Collection+.swift in Sources */,
 				D25EEC8428A1E8310090F108 /* MD5.swift in Sources */,
@@ -4776,6 +4792,7 @@
 				D276DA9521336B20007FAA31 /* AppConfiguration.swift in Sources */,
 				D2C300582E3E65AB0082C308 /* UserService.swift in Sources */,
 				D276DA9621336B20007FAA31 /* FinesViewController.swift in Sources */,
+				D2579CBC2FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */,
 				D2C300222E3C02220082C308 /* GatewayResponse+.swift in Sources */,
 				D29911E6248464AD007DB26C /* OrgDetailsViewController.swift in Sources */,
 				D2D074972E74C2F4003DFCCF /* SearchClass.swift in Sources */,
@@ -4929,6 +4946,7 @@
 				D2A74B1421289D63001D4B0F /* AppConfiguration.swift in Sources */,
 				D2C300562E3E65AB0082C308 /* UserService.swift in Sources */,
 				D29911E7248464AD007DB26C /* OrgDetailsViewController.swift in Sources */,
+				D2579CC12FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */,
 				D2C300272E3C02220082C308 /* GatewayResponse+.swift in Sources */,
 				D28F5E6429CF89BB00FAAAD6 /* Thread+.swift in Sources */,
 				D2D074952E74C2F4003DFCCF /* SearchClass.swift in Sources */,
@@ -5130,6 +5148,7 @@
 				D22438AC20D357E900D098D0 /* HoldsViewController.swift in Sources */,
 				D20D14D120B783C1008F66B0 /* CircRecord.swift in Sources */,
 				D20D14CF20B7804C008F66B0 /* CheckoutsViewController.swift in Sources */,
+				D2579CBF2FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */,
 				D253343C20C23305008176B9 /* Theme.swift in Sources */,
 				D2E7E3182F4A28350066D52B /* Collection+.swift in Sources */,
 				D2DE83ED20F5AC7B0027FAA1 /* XUtils.swift in Sources */,
@@ -5267,6 +5286,7 @@
 				D2BDA61822D176BD00D9B60C /* MainTableViewCell.swift in Sources */,
 				D2BDA61922D176BD00D9B60C /* EvergreenHoldRecord.swift in Sources */,
 				D2BDA61A22D176BD00D9B60C /* Bundle+.swift in Sources */,
+				D2579CC32FA8E2A100F8DB6B /* AttributedAlertController.swift in Sources */,
 				D29273722ED5348A004CAD82 /* HoldRecord.swift in Sources */,
 				D2BDA61B22D176BD00D9B60C /* Link.swift in Sources */,
 				D283B0C42E426A3100AE5F43 /* EvergreenOrgService.swift in Sources */,

--- a/Source/Scenes/Main/MainBaseViewController.swift
+++ b/Source/Scenes/Main/MainBaseViewController.swift
@@ -144,13 +144,26 @@ class MainBaseViewController: UIViewController {
     func showSystemAlert() {
         guard let msg = App.svc.consortium.alertBanner else { return }
         guard !systemAlertIsSquelched(msg) else { return }
-        let alertController = UIAlertController(title: "System Alert", message: msg, preferredStyle: .alert)
-        Style.styleAlertController(alertController)
-        alertController.addAction(UIAlertAction(title: "OK", style: .default))
-        alertController.addAction(UIAlertAction(title: "Don't show again", style: .default) { action in
-            self.squelchSystemAlert(msg)
-        })
-        self.present(alertController, animated: true)
+
+        // if the message looks like HTML, and parses as HTML, use a specialized alert controller;
+        // otherwise prefer the standard alert controller because it feels more native
+        if msg.looksLikeHTML,
+           let attributedString = AttributedAlertController.attributedString(fromHTML: msg)
+        {
+            let alert = AttributedAlertController(title: "Alert", message: attributedString)
+            alert.addAction(AlertAction(title: "OK", style: .default))
+            alert.addAction(AlertAction(title: "Don't show again", style: .default) {
+                self.squelchSystemAlert(msg)
+            })
+            self.present(alert, animated: true)
+        } else {
+            let alert = UIAlertController(title: "Alert", message: msg, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            alert.addAction(UIAlertAction(title: "Don't show again", style: .default) { action in
+                self.squelchSystemAlert(msg)
+            })
+            self.present(alert, animated: true)
+        }
     }
 
     func systemAlertIsSquelched(_ msg: String) -> Bool {

--- a/Source/Utils/AttributedAlertController.swift
+++ b/Source/Utils/AttributedAlertController.swift
@@ -1,0 +1,233 @@
+import UIKit
+
+final class AlertAction {
+    enum Style {
+        case `default`
+        case cancel
+        case destructive
+    }
+
+    let title: String
+    let style: Style
+    let handler: (() -> Void)?
+
+    init(title: String, style: Style = .default, handler: (() -> Void)? = nil) {
+        self.title = title
+        self.style = style
+        self.handler = handler
+    }
+}
+
+final class AttributedAlertController: UIViewController, UITextViewDelegate {
+
+    private let titleText: String?
+    private let attributedMessage: NSAttributedString
+    private var actions: [AlertAction] = []
+
+    // MARK: Init
+
+    init(title: String?, message: NSAttributedString) {
+        self.titleText = title
+        self.attributedMessage = message
+        super.init(nibName: nil, bundle: nil)
+
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: Public API
+
+    func addAction(_ action: AlertAction) {
+        actions.append(action)
+    }
+
+    /// Converts an HTML fragment to an attributed string with dynamic type and dark mode support,
+    /// or returns nil if the conversion fails.
+    static func attributedString(fromHTML html: String) -> NSAttributedString? {
+        guard let data = html.data(using: .utf8),
+              let mutable = try? NSMutableAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html], documentAttributes: nil) else { return nil }
+
+        let fullRange = NSRange(location: 0, length: mutable.length)
+
+        // The basic HTML parsing gives us a fixed-size black font, so we need to fix it.
+        // Enumerate existing attributes and replace fonts with scaled, preferred fonts
+        // preserving symbolic traits (bold/italic) where possible.
+//        mutable.enumerateAttributes(in: fullRange, options: []) { attrs, range, _ in
+//            // Determine traits from any existing font
+//            var traits = UIFontDescriptor.SymbolicTraits()
+//            if let f = attrs[.font] as? UIFont {
+//                traits = f.fontDescriptor.symbolicTraits
+//            }
+//
+//            // Create a footnote-sized font
+//            var desc = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .footnote)
+//            if let descWithTraits = desc.withSymbolicTraits(traits) {
+//                desc = descWithTraits
+//            }
+//            let resolvedFont = UIFont(descriptor: desc, size: 0)
+//            let scaled = UIFontMetrics(forTextStyle: .body).scaledFont(for: resolvedFont)
+//
+//            // Replace font and foregroundColor in this range
+//            mutable.addAttribute(.font, value: scaled, range: range)
+//            mutable.addAttribute(.foregroundColor, value: UIColor.label, range: range)
+//        }
+
+        // On further examination, it seems all we really have to do is fix the foreground color here
+        // because later we set the textView.font to a dynamic type *after* setting the attributedText
+        mutable.enumerateAttributes(in: fullRange, options: []) { attrs, range, _ in
+            mutable.addAttribute(.foregroundColor, value: UIColor.label, range: range)
+        }
+
+        return mutable
+    }
+
+    // MARK: UI
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+
+        let container = UIView()
+        //container.backgroundColor = .systemBackground
+        container.layer.cornerRadius = 14
+        container.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(container)
+
+        let blur = UIBlurEffect(style: .systemChromeMaterial)
+        let blurView = UIVisualEffectView(effect: blur)
+        blurView.layer.cornerRadius = 14
+        blurView.layer.masksToBounds = true
+        blurView.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(blurView)
+
+        NSLayoutConstraint.activate([
+            blurView.topAnchor.constraint(equalTo: container.topAnchor),
+            blurView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            blurView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            blurView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(stack)
+
+        // Title
+        if let titleText {
+            let titleLabel = UILabel()
+            titleLabel.text = titleText
+            titleLabel.font = .preferredFont(forTextStyle: .headline)
+            titleLabel.textAlignment = .center
+            titleLabel.numberOfLines = 0
+            stack.addArrangedSubview(titleLabel)
+        }
+
+        // Message (UITextView for links)
+        let textView = UITextView()
+        textView.attributedText = attributedMessage
+        textView.font = .preferredFont(forTextStyle: .footnote)
+        textView.textAlignment = .center
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.backgroundColor = .clear
+        textView.delegate = self
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+
+        // Ensure link color matches label color
+        textView.linkTextAttributes = [
+            .foregroundColor: UIColor.label
+        ]
+
+        stack.addArrangedSubview(textView)
+
+        // Buttons
+        let buttonStack = makeButtonStack()
+        stack.addArrangedSubview(buttonStack)
+
+        // Layout
+        NSLayoutConstraint.activate([
+            container.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            container.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            container.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 20),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -16),
+        ])
+    }
+
+    private func makeButtonStack() -> UIView {
+        let isVertical = actions.count > 1
+
+        let stack = UIStackView()
+        stack.axis = isVertical ? .vertical : .horizontal
+        stack.spacing = 0
+        stack.distribution = .equalSpacing
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+
+        for action in actions {
+            stack.addArrangedSubview(makeSeparator(isVertical: isVertical))
+            stack.addArrangedSubview(makeButton(for: action))
+        }
+
+        return container
+    }
+
+    private func makeSeparator(isVertical: Bool) -> UIView {
+        let view = UIView()
+        view.backgroundColor = UIColor.separator
+
+        let thickness = 1.0 / UIScreen.main.scale
+
+        if isVertical {
+            view.heightAnchor.constraint(equalToConstant: thickness).isActive = true
+        } else {
+            view.widthAnchor.constraint(equalToConstant: thickness).isActive = true
+        }
+
+        return view
+    }
+
+    private func makeButton(for action: AlertAction) -> UIButton {
+        let button = UIButton(type: .system)
+        button.setTitle(action.title, for: .normal)
+        //button.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+
+        switch action.style {
+        case .default:
+            button.setTitleColor(App.theme.accentColor, for: .normal)
+            Style.styleButton(asPlain: button)
+        case .cancel:
+            button.setTitleColor(.label, for: .normal)
+        case .destructive:
+            button.setTitleColor(.systemRed, for: .normal)
+        }
+
+        button.addAction(UIAction { [weak self] _ in
+            self?.dismiss(animated: true) {
+                action.handler?()
+            }
+        }, for: .touchUpInside)
+
+        return button
+    }
+}

--- a/Source/Utils/String+.swift
+++ b/Source/Utils/String+.swift
@@ -96,4 +96,10 @@ extension String {
         guard let data = Data(base64urlEncoded: self) else { return nil }
         return String(data: data, encoding: .utf8)
     }
+
+    /// Returns true if the string contains something like <tag>
+    var looksLikeHTML: Bool {
+        let pattern = "<[^>]+>"
+        return range(of: pattern, options: .regularExpression) != nil
+    }
 }


### PR DESCRIPTION
UIAlertController does not handle HTML with links.  You can replace its text with attributed text converted from HTML but then the links are not clickable.  You can Jerry-rig a solution by modifying the UIAlertController, but that seems fragile and did not look good.  So we introduce a modal AttributedAlertController that handles HTML-like fragments and allows tapping the links.  If the system message does not look like HTML, we fall back to UIAlertController, because Apple is forever tweaking it, as they did again in iOS 26.  This implementation looks like iOS 18 and earlier alerts.